### PR TITLE
ignore XDS packets

### DIFF
--- a/lib/cea608-parser.js
+++ b/lib/cea608-parser.js
@@ -852,6 +852,9 @@
                 }
                 cmdFound = this.parseCmd(a, b);
                 if (!cmdFound) {
+                    cmdFound = this.parseXDSCmd(a, b);
+                }
+                if (!cmdFound) {
                     cmdFound = this.parseMidrow(a, b);
                 }
                 if (!cmdFound) {
@@ -945,6 +948,17 @@
             this.lastCmdB = b;
             this.currChNr = chNr;
             return true;
+        },
+
+        /**
+         * Parse XDS command packet
+         */
+        parseXDSCmd: function(a, b) {
+          if (a < 0x10) {
+            // this is an XDS packet
+            this.currChNr = -1;
+            return true;
+          }
         },
 
         /**


### PR DESCRIPTION
I'm having a problem with dash.js where XDS packets are causing tons of errors in the console. This PR properly drops XDS packets by setting the current channel to be `-1` when an XDS start/stop packet is received.