### PR TITLE
Handle CRLF and tabs in SCC files, and fix timecode parsing

### DIFF
--- a/lib/cea608-parser.js
+++ b/lib/cea608-parser.js
@@ -834,6 +834,9 @@
             logger.setTime(t);
 
             for (var i = 0 ; i < byteList.length ; i+=2) {
+                t = this.lastTime + 0.5 * i * 1001 / 30000;
+                logger.setTime(t);
+
                 a = byteList[i] & 0x7f;
                 b = byteList[i+1] & 0x7f;
 

--- a/lib/scc-parser.js
+++ b/lib/scc-parser.js
@@ -40,7 +40,7 @@ var SccParser = function(filePath, processor, field) {
 
 SccParser.prototype.parse = function() {
     var lineData,
-        lines = fs.readFileSync(this.filePath, 'utf8').split("\n");
+        lines = fs.readFileSync(this.filePath, 'utf8').split(/\r?\n/);
         
         this.nrLinesParsed = 0;
         
@@ -70,7 +70,7 @@ SccParser.prototype.parseDataLine = function(line)
     if (!line) {
         return null;
     }
-    var lineParts = line.split(" ");
+    var lineParts = line.split(/\s/);
     var timeData = lineParts[0];
     var ceaData = [];
     var a, b, fourHexChars;
@@ -86,8 +86,9 @@ SccParser.prototype.parseDataLine = function(line)
             parts[2] = last_parts[0];
             parts[3] = last_parts[1];
         }
-        return parseInt(parts[0])*3600 + parseInt(parts[1])*60 + parseInt(parts[2])+
-            parseInt(parts[3])/30.0;        
+        return
+            (30 * (60 * (60 * parseInt(parts[0]) + parseInt(parts[1])) + parseInt(parts[2])) + parseInt(parts[3]))
+            * 1001 / 30000;
     };
     
     for (var i=1 ; i < lineParts.length ; i++) {


### PR DESCRIPTION
Many SCC files use CRLF line terminators.
Also, some SCC files have a tab between the SMPTE time code and the first hex pair. These changes take care of that.

Also fix incorrect parsing of timecodes and incorrect time handling in general:
* SCC files should always use a time base of 1001 / 30000, but the old code assumed a time base of 1 / 30
* The time code at the beginning of each line in an SCC file is not the time at which the caption should be displayed on screen, but rather the time code of the first hex pair, so the current time must be advanced by one frame per hex pair (0.5 frames per hex value) and the caption is displayed at the time when `942f` is encountered and removed at `942c`

Known issues not fixed in this PR:
* Handle drop-frame time codes